### PR TITLE
fix: Namespace

### DIFF
--- a/src/components/AuthorInfo.vue
+++ b/src/components/AuthorInfo.vue
@@ -51,12 +51,12 @@ export default {
 	color: #fff;
 }
 
-.compact-mode .discord-message .discord-author-info {
+.discord-compact-mode .discord-message .discord-author-info {
 	display: inline-flex;
 	flex-direction: row-reverse;
 }
 
-.compact-mode .discord-message .discord-author-info .discord-bot-tag {
+.discord-compact-mode .discord-message .discord-author-info .discord-bot-tag {
 	margin-left: 0;
 	margin-right: 5px;
 	padding-left: 3px;

--- a/src/components/AuthorInfo.vue
+++ b/src/components/AuthorInfo.vue
@@ -1,9 +1,9 @@
 <template>
-	<span class="author-info">
-		<span :style="{ color: roleColor }" class="author-username">
+	<span class="discord-author-info">
+		<span :style="{ color: roleColor }" class="discord-author-username">
 			<slot></slot>
 		</span>
-		<span v-if="bot" class="bot-tag">
+		<span v-if="bot" class="discord-bot-tag">
 			Bot
 		</span>
 	</span>
@@ -21,23 +21,23 @@ export default {
 </script>
 
 <style>
-.discord-message .author-info {
+.discord-message .discord-author-info {
 	display: inline-flex;
 	align-items: center;
 	font-size: 15px;
 }
 
-.discord-message .author-info .author-username {
+.discord-message .discord-author-info .discord-author-username {
 	font-size: 1.1em;
 	font-weight: 500;
 	letter-spacing: 0.5px;
 }
 
-.discord-light-theme .discord-message .author-info .author-username {
+.discord-light-theme .discord-message .discord-author-info .discord-author-username {
 	color: #23262a;
 }
 
-.discord-message .author-info .bot-tag {
+.discord-message .discord-author-info .discord-bot-tag {
 	background-color: #7289da;
 	font-size: 0.65em;
 	margin-left: 5px;
@@ -47,16 +47,16 @@ export default {
 	text-transform: uppercase;
 }
 
-.discord-light-theme .discord-message .author-info .bot-tag {
+.discord-light-theme .discord-message .discord-author-info .discord-bot-tag {
 	color: #fff;
 }
 
-.compact-mode .discord-message .author-info {
+.compact-mode .discord-message .discord-author-info {
 	display: inline-flex;
 	flex-direction: row-reverse;
 }
 
-.compact-mode .discord-message .author-info .bot-tag {
+.compact-mode .discord-message .discord-author-info .discord-bot-tag {
 	margin-left: 0;
 	margin-right: 5px;
 	padding-left: 3px;

--- a/src/components/DiscordEmbed.vue
+++ b/src/components/DiscordEmbed.vue
@@ -158,7 +158,7 @@ export default {
 	color: #4f545c;
 }
 
-.discord-embed .embed-author .discord-author-image {
+.discord-embed .discord-embed-author .discord-author-image {
 	width: 20px;
 	height: 20px;
 	margin-right: 8px;

--- a/src/components/DiscordEmbed.vue
+++ b/src/components/DiscordEmbed.vue
@@ -1,11 +1,11 @@
 <template>
 	<div class="discord-embed">
-		<div :style="{ 'background-color': color }" class="left-border"></div>
-		<div class="embed-container">
-			<div class="embed-content">
+		<div :style="{ 'background-color': color }" class="discord-left-border"></div>
+		<div class="discord-embed-container">
+			<div class="discord-embed-content">
 				<div>
-					<div v-if="author.name" class="embed-author">
-						<img v-if="author.image" :src="author.image" alt="" class="author-image" />
+					<div v-if="author.name" class="discord-embed-author">
+						<img v-if="author.image" :src="author.image" alt="" class="discord-author-image" />
 						<a v-if="author.url" :href="author.url" target="_blank">
 							{{ author.name }}
 						</a>
@@ -13,7 +13,7 @@
 							{{ author.name }}
 						</span>
 					</div>
-					<div v-if="title" class="embed-title">
+					<div v-if="title" class="discord-embed-title">
 						<a v-if="url" :href="url" target="_blank">
 							{{ title }}
 						</a>
@@ -21,19 +21,19 @@
 							{{ title }}
 						</span>
 					</div>
-					<div class="embed-description">
+					<div class="discord-embed-description">
 						<slot></slot>
 					</div>
-					<slot name="fields"></slot>
-					<img v-if="image" :src="image" class="embed-image" alt="" />
+					<slot name="discord-fields"></slot>
+					<img v-if="image" :src="image" class="discord-embed-image" alt="" />
 				</div>
-				<img v-if="thumbnail" :src="thumbnail" alt="" class="embed-thumbnail" />
+				<img v-if="thumbnail" :src="thumbnail" alt="" class="discord-embed-thumbnail" />
 			</div>
-			<div v-if="showFooter" class="embed-footer">
-				<img v-if="showFooterImage" :src="footerImage" alt="" class="footer-image" />
+			<div v-if="showFooter" class="discord-embed-footer">
+				<img v-if="showFooterImage" :src="footerImage" alt="" class="discord-footer-image" />
 				<span>
 					<slot name="footer"></slot>
-					<span v-if="showFooterSeparator" class="footer-separator">
+					<span v-if="showFooterSeparator" class="discord-footer-separator">
 						&bull;
 					</span>
 					<span v-if="timestamp">
@@ -103,18 +103,18 @@ export default {
 	color: rgba(79, 83, 91, 0.9);
 }
 
-.discord-embed .left-border {
+.discord-embed .discord-left-border {
 	background-color: #4f545c;
 	flex-shrink: 0;
 	width: 4px;
 	border-radius: 3px 0 0 3px;
 }
 
-.discord-light-theme .discord-embed .left-border {
+.discord-light-theme .discord-embed .discord-left-border {
 	background-color: #cacbce;
 }
 
-.discord-embed .embed-container {
+.discord-embed .discord-embed-container {
 	background-color: rgba(46, 48, 54, 0.3);
 	display: flex;
 	flex-direction: column;
@@ -124,65 +124,65 @@ export default {
 	border-radius: 0 3px 3px 0;
 }
 
-.discord-light-theme .discord-embed .embed-container {
+.discord-light-theme .discord-embed .discord-embed-container {
 	background-color: rgba(249, 249, 249, 0.3);
 	border-color: rgba(205, 205, 205, 0.3);
 }
 
-.discord-embed .embed-content {
+.discord-embed .discord-embed-content {
 	display: flex;
 }
 
-.discord-embed .embed-thumbnail {
+.discord-embed .discord-embed-thumbnail {
 	width: 80px;
 	height: 80px;
 	margin-left: 1em;
 	border-radius: 3px;
 }
 
-.discord-embed .embed-author {
+.discord-embed .discord-embed-author {
 	color: #fff;
 	display: flex;
 	font-weight: 500;
 }
 
-.discord-light-theme .discord-embed .embed-author {
+.discord-light-theme .discord-embed .discord-embed-author {
 	color: #4f545c;
 }
 
-.discord-embed .embed-author a {
+.discord-embed .discord-embed-author a {
 	color: #fff;
 }
 
-.discord-light-theme .discord-embed .embed-author a {
+.discord-light-theme .discord-embed .discord-embed-author a {
 	color: #4f545c;
 }
 
-.discord-embed .embed-author .author-image {
+.discord-embed .embed-author .discord-author-image {
 	width: 20px;
 	height: 20px;
 	margin-right: 8px;
 	border-radius: 50%;
 }
-.discord-embed .embed-title {
+.discord-embed .discord-embed-title {
 	color: #fff;
 	font-weight: 500;
 }
 
-.discord-embed .embed-image {
+.discord-embed .discord-embed-image {
 	max-width: 100%;
 	margin-top: 8px;
 	border-radius: 3px;
 }
 
-.discord-embed .embed-footer {
+.discord-embed .discord-embed-footer {
 	display: flex;
 	align-items: center;
 	font-size: 0.85em;
 	margin-top: 8px;
 }
 
-.discord-embed .embed-footer .footer-image {
+.discord-embed .discord-embed-footer .discord-footer-image {
 	flex-shrink: 0;
 	width: 20px;
 	height: 20px;
@@ -190,7 +190,7 @@ export default {
 	border-radius: 50%;
 }
 
-.discord-embed .embed-footer .footer-separator {
+.discord-embed .discord-embed-footer .discord-footer-separator {
 	color: #4f545c;
 	font-weight: 700;
 	margin: 0 5px;

--- a/src/components/DiscordMessage.vue
+++ b/src/components/DiscordMessage.vue
@@ -1,23 +1,23 @@
 <template>
 	<div class="discord-message">
-		<div class="author-avatar">
+		<div class="discord-author-avatar">
 			<img :src="avatarSrc" :alt="author" />
 		</div>
-		<div class="message-content">
+		<div class="discord-message-content">
 			<div v-if="!compactMode">
 				<author-info :bot="bot" :role-color="roleColor">
 					{{ author }}
 				</author-info>
-				<span v-if="timestamp" class="message-timestamp">
+				<span v-if="timestamp" class="discord-message-timestamp">
 					{{ timestamp | formatDate | padZeroes }}
 				</span>
 			</div>
-			<div :class="{ 'highlight-mention': highlightMention }" class="message-body">
+			<div :class="{ 'discord-highlight-mention': highlightMention }" class="discord-message-body">
 				<author-info v-if="compactMode" :bot="bot" :role-color="roleColor">
 					{{ author }}
 				</author-info>
 				<slot></slot>
-				<span v-if="edited" class="message-edited">(edited)</span>
+				<span v-if="edited" class="discord-message-edited">(edited)</span>
 			</div>
 			<slot name="embeds"></slot>
 		</div>
@@ -105,33 +105,33 @@ export default {
 	text-decoration: underline;
 }
 
-.discord-message .author-avatar {
+.discord-message .discord-author-avatar {
 	margin-right: 1rem;
 	min-width: 40px;
 }
 
-.discord-message .author-avatar img {
+.discord-message .discord-author-avatar img {
 	width: 40px;
 	height: 40px;
 	border-radius: 50%;
 }
 
-.discord-message .message-timestamp {
+.discord-message .discord-message-timestamp {
 	color: #fff3;
 	font-size: 0.75rem;
 	margin-left: 0.3rem;
 }
 
-.discord-message .message-edited {
+.discord-message .discord-message-edited {
 	color: #fff3;
 	font-size: 10px;
 }
 
-.discord-message .message-content {
+.discord-message .discord-message-content {
 	width: 100%;
 }
 
-.discord-message .message-body {
+.discord-message .discord-message-body {
 	position: relative;
 }
 
@@ -140,11 +140,11 @@ export default {
 	padding-bottom: 0.5em;
 }
 
-.compact-mode .author-avatar {
+.compact-mode .discord-author-avatar {
 	display: none;
 }
 
-.compact-mode .message-body {
+.compact-mode .discord-message-body {
 	margin-left: 0.25em;
 }
 </style>

--- a/src/components/DiscordMessage.vue
+++ b/src/components/DiscordMessage.vue
@@ -135,16 +135,16 @@ export default {
 	position: relative;
 }
 
-.compact-mode .discord-message {
+.discord-compact-mode .discord-message {
 	padding-top: 0.5em;
 	padding-bottom: 0.5em;
 }
 
-.compact-mode .discord-author-avatar {
+.discord-compact-mode .discord-author-avatar {
 	display: none;
 }
 
-.compact-mode .discord-message-body {
+.discord-compact-mode .discord-message-body {
 	margin-left: 0.25em;
 }
 </style>

--- a/src/components/DiscordMessages.vue
+++ b/src/components/DiscordMessages.vue
@@ -17,7 +17,7 @@ export default {
 		return {
 			layout: {
 				'discord-light-theme': this.lightTheme,
-				'compact-mode': this.compactMode,
+				'discord-compact-mode': this.compactMode,
 			},
 		};
 	},

--- a/src/components/EmbedField.vue
+++ b/src/components/EmbedField.vue
@@ -1,6 +1,6 @@
 <template>
-	<div :class="{ 'inline-field': inline }" class="embed-field">
-		<div class="field-title">{{ title }}</div>
+	<div :class="{ 'discord-inline-field': inline }" class="discord-embed-field">
+		<div class="discord-field-title">{{ title }}</div>
 		<slot></slot>
 	</div>
 </template>
@@ -20,24 +20,24 @@ export default {
 </script>
 
 <style>
-.discord-embed .embed-field {
+.discord-embed .discord-embed-field {
 	min-width: 100%;
 	margin-top: 5px;
 }
 
-.discord-embed .embed-field.inline-field {
+.discord-embed .discord-embed-field.discord-inline-field {
 	flex-grow: 1;
 	flex-basis: auto;
 	min-width: 150px;
 }
 
-.discord-embed .embed-field .field-title {
+.discord-embed .discord-embed-field .discord-field-title {
 	color: #fff;
 	font-weight: 500;
 	margin-bottom: 5px;
 }
 
-.discord-light-theme .discord-embed .embed-field .field-title {
+.discord-light-theme .discord-embed .discord-embed-field .discord-field-title {
 	color: rgba(79, 83, 91, 0.9);
 }
 </style>

--- a/src/components/EmbedFields.vue
+++ b/src/components/EmbedFields.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="embed-fields">
+	<div class="discord-embed-fields">
 		<slot></slot>
 	</div>
 </template>
@@ -11,7 +11,7 @@ export default {
 </script>
 
 <style>
-.discord-embed .embed-fields {
+.discord-embed .discord-embed-fields {
 	display: flex;
 	flex-wrap: wrap;
 	margin-top: 5px;

--- a/src/components/Mention.vue
+++ b/src/components/Mention.vue
@@ -77,7 +77,7 @@ export default {
 	background-color: rgba(114, 137, 218, 0.7);
 }
 
-.discord-message .message-body.highlight-mention {
+.discord-message .discord-message-body.discord-highlight-mention {
 	background-color: rgba(250, 166, 26, 0.1);
 	border-radius: 0 3px 3px 0;
 	margin: -0.1rem -0.2rem 0.1rem;
@@ -85,7 +85,7 @@ export default {
 	padding-right: 0.3rem;
 }
 
-.discord-message .message-body.message-body.highlight-mention::before {
+.discord-message .discord-message-body.discord-message-body.discord-highlight-mention::before {
 	content: " ";
 	background-color: rgba(250, 166, 26, 0.2);
 	position: absolute;
@@ -97,11 +97,11 @@ export default {
 	border-radius: 3px 0 0 3px;
 }
 
-.discord-message .message-body.highlight-mention .discord-mention {
+.discord-message .discord-message-body.discord-highlight-mention .discord-mention {
 	background-color: unset !important;
 }
 
-.discord-message .message-body.highlight-mention .discord-mention:hover {
+.discord-message .discord-message-body.discord-highlight-mention .discord-mention:hover {
 	color: #7289da;
 	text-decoration: underline;
 }


### PR DESCRIPTION
Some CSS classes might collide with other CSS Frameworks (*coughs* Bulma) which causes issues if you use both.

This PR makes every class part of the `discord` namespace by adding `discord-` in front

## Question

@Danktuary how would I rename compact-mode and make sure it works?