### PR TITLE
Change min-width to allow 3 inline fields in one row

### DIFF
--- a/src/components/EmbedField.vue
+++ b/src/components/EmbedField.vue
@@ -27,7 +27,7 @@ export default {
 .discord-embed .discord-embed-field.discord-inline-field {
 	flex-grow: 1;
 	flex-basis: auto;
-	min-width: 150px;
+	min-width: 100px;
 }
 
 .discord-embed .discord-embed-field .discord-field-title {


### PR DESCRIPTION
I am not sure if that's enough to make it consistent in any way, but i was fiddling around with discord.js embed guide's [embed preview](https://discordjs.guide/popular-topics/embeds.html#embed-preview) after i noticed that code has 3 inline fields, while embed puts 3rd on next line, and this did the job for that particular example.