### PR TITLE
feat(*): Update default avatar images.

### DIFF
--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -42,15 +42,16 @@ Vue.use(VueDiscordMessage, {
 
 ## Avatar shortcuts
 
-The current avatar shortcut strings available are "blue" (default), "gray", "green", "orange", and "red". These shortcuts map to the following image links:
+The current avatar shortcut strings available are "blue" (default), "gray", "green", "yellow", "red", and "pink". These shortcuts map to the following image links:
 
 ```json
 {
-	"blue": "https://cdn.discordapp.com/attachments/654503812593090602/665721745466195978/blue.png",
-	"gray": "https://cdn.discordapp.com/attachments/654503812593090602/665721746569166849/gray.png",
-	"green": "https://cdn.discordapp.com/attachments/654503812593090602/665721748431306753/green.png",
-	"orange": "https://cdn.discordapp.com/attachments/654503812593090602/665721750201434138/orange.png",
-	"red": "https://cdn.discordapp.com/attachments/654503812593090602/665721752277483540/red.png"
+	"blue": "https://cdn.discordapp.com/embed/avatars/0.png",
+	"gray": "https://cdn.discordapp.com/embed/avatars/1.png",
+	"green": "https://cdn.discordapp.com/embed/avatars/2.png",
+	"yellow": "https://cdn.discordapp.com/embed/avatars/3.png",
+	"red": "https://cdn.discordapp.com/embed/avatars/4.png",
+	"pink": "https://cdn.discordapp.com/embed/avatars/5.png",
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,12 @@ export default {
 		const { avatars = {}, componentNames = {}, profiles = {} } = options;
 
 		const discordAvatars = {
-			blue: 'https://cdn.discordapp.com/attachments/654503812593090602/665721745466195978/blue.png',
-			gray: 'https://cdn.discordapp.com/attachments/654503812593090602/665721746569166849/gray.png',
-			green: 'https://cdn.discordapp.com/attachments/654503812593090602/665721748431306753/green.png',
-			orange: 'https://cdn.discordapp.com/attachments/654503812593090602/665721750201434138/orange.png',
-			red: 'https://cdn.discordapp.com/attachments/654503812593090602/665721752277483540/red.png',
+			blue: 'https://cdn.discordapp.com/embed/avatars/0.png',
+			gray: 'https://cdn.discordapp.com/embed/avatars/1.png',
+			green: 'https://cdn.discordapp.com/embed/avatars/2.png',
+			yellow: 'https://cdn.discordapp.com/embed/avatars/3.png',
+			red: 'https://cdn.discordapp.com/embed/avatars/4.png',
+			pink: 'https://cdn.discordapp.com/embed/avatars/5.png',			
 		};
 
 		Vue.prototype.$discordMessage = {


### PR DESCRIPTION
This PR updates the old default avatars to the new ones.

⚠️ This is a breaking change as it removes the `orange` avatar and replaces it with a `yellow` one.
ℹ️ This also adds a new `pink` avatar. Alternatively, this could be named `fuchsia`.